### PR TITLE
refactor: exchange rate open api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.session:spring-session-core'
 
 	implementation 'org.jsoup:jsoup:1.18.1'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2024.0.0")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -44,6 +48,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.h2database:h2'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -24,17 +24,24 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
+
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.session:spring-session-core'
+
+	implementation 'org.jsoup:jsoup:1.18.1'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-  runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
 	runtimeOnly 'com.h2database:h2'
 }
 

--- a/src/main/java/SN/BANK/SnBankApplication.java
+++ b/src/main/java/SN/BANK/SnBankApplication.java
@@ -2,8 +2,10 @@ package SN.BANK;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients(basePackages = "SN.BANK.exchangeRate")
 public class SnBankApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/SN/BANK/common/exception/ErrorCode.java
+++ b/src/main/java/SN/BANK/common/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 
     // ExchangeRate
     EXCHANGE_RATE_FETCH_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "환율 데이터를 가져올 수 없습니다."),
+    INVALID_QUOTE_CURRENCY_ERROR(HttpStatus.BAD_REQUEST, "Quote Currency는 한국 원화(KRW) 단위여야 합니다."),
 
     // Payment
     PAYMENT_ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 결제 취소된 내역입니다."),

--- a/src/main/java/SN/BANK/exchangeRate/ExchangeRateOpenApiInterface.java
+++ b/src/main/java/SN/BANK/exchangeRate/ExchangeRateOpenApiInterface.java
@@ -1,0 +1,10 @@
+package SN.BANK.exchangeRate;
+
+import SN.BANK.account.enums.Currency;
+
+import java.math.BigDecimal;
+
+public interface ExchangeRateOpenApiInterface {
+
+	BigDecimal getExchangeRate(Currency baseCurrency, Currency quoteCurrency);
+}

--- a/src/main/java/SN/BANK/exchangeRate/ExchangeRateService.java
+++ b/src/main/java/SN/BANK/exchangeRate/ExchangeRateService.java
@@ -3,66 +3,186 @@ package SN.BANK.exchangeRate;
 import SN.BANK.account.enums.Currency;
 import SN.BANK.common.exception.CustomException;
 import SN.BANK.common.exception.ErrorCode;
+import SN.BANK.exchangeRate.google.ExchangeRateGoogleFinanceScraper;
+import SN.BANK.exchangeRate.manana.ExchangeRateMananaService;
+import SN.BANK.exchangeRate.naver.ExchangeRateNaverService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class ExchangeRateService {
 
-    private final RestTemplate restTemplate;
+    private final ExchangeRateNaverService naverService;
+    private final ExchangeRateMananaService mananaService;
+    private final ExchangeRateGoogleFinanceScraper googleFinanceScraper;
+
+    private final ConcurrentHashMap<Currency, ReentrantLock> currencyLocks = new ConcurrentHashMap<>();
+    private final Map<Currency, ExchangeRateStatus> exchangeRateResults = new ConcurrentHashMap<>();
+
+    // TODO: 동적 변경 예정
+    private final long CACHE_EXPIRY_TIME = 2000;
+
+    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        .withZone(ZoneId.systemDefault());
 
     public BigDecimal getExchangeRate(Currency fromCurrency, Currency toCurrency) {
         if (fromCurrency.equals(toCurrency)) { //둘다 원화일 경우
             return BigDecimal.ONE;
         }
 
-        Currency baseCurrency;
+        Currency baseCurrency, quoteCurrency;
         boolean isInverse = false; // 역수 계산 여부 플래그
 
-        if (fromCurrency.equals(Currency.KRW)) {
-            baseCurrency = toCurrency; // 원화 -> 외화
-        } else if (toCurrency.equals(Currency.KRW)) {
-            baseCurrency = fromCurrency; // 외화 -> 원화
+        if (fromCurrency.equals(Currency.KRW)) {  // 원화 -> 외화
+            baseCurrency = toCurrency;
+            quoteCurrency = fromCurrency;
+        } else if (toCurrency.equals(Currency.KRW)) {  // 외화 -> 원화
+            baseCurrency = fromCurrency;
+            quoteCurrency = toCurrency;
             isInverse = true; // 역수 계산 필요
         } else {
             throw new CustomException(ErrorCode.EXCHANGE_RATE_FETCH_FAIL); // 외화 -> 외화
         }
 
-        // Naver API URL
-        String apiUrl = "https://m.search.naver.com/p/csearch/content/qapirender.nhn";
+        BigDecimal exchangeRate = null;
+        long currentTime = System.currentTimeMillis();
+        long timeout = 4000;
+        long endTime = currentTime + timeout;
+        boolean timeoutFlag = true;
 
-        // API 요청 파라미터 구성
-        String url = UriComponentsBuilder.fromUriString(apiUrl)
-                .queryParam("key", "calculator")
-                .queryParam("pkid", 141)
-                .queryParam("q", "환율")
-                .queryParam("where", "m")
-                .queryParam("u1", "keb")
-                .queryParam("u2", 1)
-                .queryParam("u3", baseCurrency) // 기준 통화
-                .queryParam("u4", "KRW")  //변환 통화
-                .queryParam("u6", "standardUnit")
-                .queryParam("u7", "0")
-                .queryParam("u8", "down")
-                .toUriString();
-
-        // API 호출 및 응답 처리
-        try {
-            ExchangeRateResponseDto response = restTemplate.getForObject(url, ExchangeRateResponseDto.class);
-
-            if (response != null && response.getCountry().size() == 2) {
-                BigDecimal exchangeRate = new BigDecimal(response.getCountry().get(1).getValue().replace(",", ""));
-                return isInverse ? BigDecimal.ONE.divide(exchangeRate, 20, BigDecimal.ROUND_HALF_UP) : exchangeRate;
-            } else {
-                throw new CustomException(ErrorCode.EXCHANGE_RATE_FETCH_FAIL);
+        while (System.currentTimeMillis() < endTime) {
+            // 로컬 캐시 사용
+            if (isAvailableExchangeRate(baseCurrency)) {
+                exchangeRate = getUpdatedExchangeRate(baseCurrency);
+                timeoutFlag = false;
+                break;
             }
-        } catch (Exception e) {
+
+            // 실시간 환율 데이터 업데이트 (스레드 1개로 제한)
+            updateExchangeRate(baseCurrency, quoteCurrency);
+
+            try {
+                if (!isAvailableExchangeRate(baseCurrency)) {
+                    // TODO: Context Switching 문제로 시간 변경 예정
+                    Thread.sleep(150);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("환율 조회 중 인터럽트 발생", e);
+            }
+        }
+
+        if (timeoutFlag || exchangeRate.compareTo(BigDecimal.ZERO) <= 0) {
+            log.warn("[ Timeout ] 현재 실시간 환율을 이용할 수 없습니다. " + Thread.currentThread().getName());
             throw new CustomException(ErrorCode.EXCHANGE_RATE_FETCH_FAIL);
         }
+
+        return isInverse ? BigDecimal.ONE.divide(exchangeRate, 20, BigDecimal.ROUND_HALF_UP) : exchangeRate;
+    }
+
+    private boolean isAvailableExchangeRate(Currency currency) {
+        return exchangeRateResults.containsKey(currency)
+            && System.currentTimeMillis() - exchangeRateResults.get(currency).lastCachedTime < CACHE_EXPIRY_TIME;
+    }
+
+    private BigDecimal getUpdatedExchangeRate(Currency currency) {
+        return exchangeRateResults.get(currency).exchangeRate;
+    }
+
+    private void updateExchangeRate(Currency baseCurrency, Currency quoteCurrency) {
+        if(isAvailableExchangeRate(baseCurrency)) {
+            return;
+        }
+
+        ReentrantLock lock = currencyLocks.computeIfAbsent(baseCurrency, k -> new ReentrantLock());
+        if(lock.tryLock()) {
+            try {
+                // double checking
+                if (isAvailableExchangeRate(baseCurrency)) {
+                    return;
+                }
+
+                CompletableFuture
+                    .supplyAsync(() -> naverService.getExchangeRate(baseCurrency, quoteCurrency))
+                    .orTimeout(CACHE_EXPIRY_TIME, TimeUnit.MILLISECONDS)
+                    .thenApply(result -> new BigDecimal(result.toString())
+                        .setScale(2, RoundingMode.CEILING))
+                    .thenApply(exchangeRate -> {
+                        updateExchangeRateStatus(baseCurrency, exchangeRate);
+
+                        log.info("[Main(Naver)] {} 환율 {} 업데이트, {}",
+                            quoteCurrency,
+                            exchangeRate,
+                            formatter.format(Instant.ofEpochMilli(exchangeRateResults.get(baseCurrency).lastCachedTime)));
+                        return exchangeRate;
+                    })
+                    .exceptionally(ex -> {
+                        log.error("Naver API failed or timed out, calling Manana and Google... {}", ex.getMessage());
+                        fallbackUpdate(baseCurrency, quoteCurrency);
+                        return null;
+                    }).join();
+            } finally {
+                lock.unlock();
+            }
+        } else {
+            log.info("다른 스레드에 의해 {} 단위가 업데이트 중입니다.", baseCurrency);
+        }
+    }
+
+    private void fallbackUpdate(Currency baseCurrency, Currency quoteCurrency) {
+        CompletableFuture
+            .anyOf(
+                CompletableFuture
+                    .supplyAsync(() -> mananaService.getExchangeRate(baseCurrency, quoteCurrency))
+                    .orTimeout(CACHE_EXPIRY_TIME, TimeUnit.MILLISECONDS),
+
+                CompletableFuture
+                    .supplyAsync(() -> googleFinanceScraper.getExchangeRate(baseCurrency, quoteCurrency))
+                    .orTimeout(CACHE_EXPIRY_TIME, TimeUnit.MILLISECONDS))
+
+            .thenApply(result -> new BigDecimal(result.toString())
+                .setScale(2, RoundingMode.CEILING))
+            .thenApply(exchangeRate -> {
+                updateExchangeRateStatus(baseCurrency, exchangeRate);
+
+                log.info("[Fallback] {} 환율 {} 업데이트, {}",
+                    baseCurrency,
+                    exchangeRate,
+                    formatter.format(Instant.ofEpochMilli(exchangeRateResults.get(baseCurrency).lastCachedTime)));
+
+                return exchangeRate;
+            })
+            .exceptionally(ex -> {
+                log.error(ex.getMessage());
+                throw new RuntimeException("Unable to fetch exchange rate", ex);
+            })
+            .join();
+    }
+
+    private void updateExchangeRateStatus(Currency baseCurrency, BigDecimal exchangeRate) {
+        ExchangeRateStatus status = exchangeRateResults.computeIfAbsent(baseCurrency, k -> new ExchangeRateStatus());
+        status.exchangeRate = exchangeRate;
+        status.lastCachedTime = System.currentTimeMillis();
+    }
+
+    class ExchangeRateStatus {
+        BigDecimal exchangeRate;
+        Long lastCachedTime;
+
+        public ExchangeRateStatus() {}
     }
 }

--- a/src/main/java/SN/BANK/exchangeRate/google/ExchangeRateGoogleFinanceScraper.java
+++ b/src/main/java/SN/BANK/exchangeRate/google/ExchangeRateGoogleFinanceScraper.java
@@ -1,0 +1,48 @@
+package SN.BANK.exchangeRate.google;
+
+import SN.BANK.account.enums.Currency;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Component
+@Slf4j
+public class ExchangeRateGoogleFinanceScraper {
+
+	public BigDecimal getExchangeRate(Currency fromCurrency, Currency toCurrency){
+		String url = "https://www.google.com/finance/quote/" + fromCurrency + "-" + toCurrency;
+
+		try {
+			Document doc = Jsoup.connect(url)
+				.userAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+				.timeout(2000)
+				.get();
+
+			Element titleElement = doc.selectFirst("div.YMlKec.fxKbKc");
+			if (titleElement != null) {
+				log.info("Successfully received exchange rate information: {} to {} is {}", fromCurrency, toCurrency, titleElement.text());
+				return convertToBigDecimal(titleElement.text());
+			} else {
+				log.warn("No exchange rate information found for: {} to {}", fromCurrency, toCurrency);
+				throw new IllegalArgumentException("No exchange rate information found for: " + fromCurrency + " to " + toCurrency);
+			}
+		} catch (IOException e) {
+			log.error("IO exception occurred: ", e);
+			throw new RuntimeException("\"Failed to fetch exchange rate due to IO issue. ", e);
+		} catch (IllegalArgumentException e) {
+			throw e;
+		}
+	}
+
+	private BigDecimal convertToBigDecimal(String text) {
+		// 1,458.3890 -> 1458.39
+		String exchangeRate = text.replace(",", "");
+		return new BigDecimal(exchangeRate).setScale(2, RoundingMode.CEILING);
+	}
+}

--- a/src/main/java/SN/BANK/exchangeRate/google/ExchangeRateGoogleFinanceScraper.java
+++ b/src/main/java/SN/BANK/exchangeRate/google/ExchangeRateGoogleFinanceScraper.java
@@ -1,6 +1,7 @@
 package SN.BANK.exchangeRate.google;
 
 import SN.BANK.account.enums.Currency;
+import SN.BANK.exchangeRate.ExchangeRateOpenApiInterface;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -13,10 +14,11 @@ import java.math.RoundingMode;
 
 @Component
 @Slf4j
-public class ExchangeRateGoogleFinanceScraper {
+public class ExchangeRateGoogleFinanceScraper implements ExchangeRateOpenApiInterface {
 
-	public BigDecimal getExchangeRate(Currency fromCurrency, Currency toCurrency){
-		String url = "https://www.google.com/finance/quote/" + fromCurrency + "-" + toCurrency;
+	@Override
+	public BigDecimal getExchangeRate(Currency baseCurrency, Currency quoteCurrency) {
+		String url = "https://www.google.com/finance/quote/" + baseCurrency + "-" + quoteCurrency;
 
 		try {
 			Document doc = Jsoup.connect(url)
@@ -26,11 +28,11 @@ public class ExchangeRateGoogleFinanceScraper {
 
 			Element titleElement = doc.selectFirst("div.YMlKec.fxKbKc");
 			if (titleElement != null) {
-				log.info("Successfully received exchange rate information: {} to {} is {}", fromCurrency, toCurrency, titleElement.text());
+				log.info("Successfully received exchange rate information: {} to {} is {}", baseCurrency, quoteCurrency, titleElement.text());
 				return convertToBigDecimal(titleElement.text());
 			} else {
-				log.warn("No exchange rate information found for: {} to {}", fromCurrency, toCurrency);
-				throw new IllegalArgumentException("No exchange rate information found for: " + fromCurrency + " to " + toCurrency);
+				log.warn("No exchange rate information found for: {} to {}", baseCurrency, quoteCurrency);
+				throw new IllegalArgumentException("No exchange rate information found for: " + baseCurrency + " to " + quoteCurrency);
 			}
 		} catch (IOException e) {
 			log.error("IO exception occurred: ", e);

--- a/src/main/java/SN/BANK/exchangeRate/manana/ExchangeRateMananaClient.java
+++ b/src/main/java/SN/BANK/exchangeRate/manana/ExchangeRateMananaClient.java
@@ -1,0 +1,22 @@
+package SN.BANK.exchangeRate.manana;
+
+import SN.BANK.account.enums.Currency;
+import SN.BANK.exchangeRate.manana.dto.ExchangeRateMananaResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@FeignClient(
+	name = "manana-exchange-rate-client",
+	url = "https://api.manana.kr/exchange"
+)
+public interface ExchangeRateMananaClient {
+
+	@GetMapping("/rate.json")
+	List<ExchangeRateMananaResponseDto> getExchangeRate(
+		@RequestParam("base") Currency base,
+		@RequestParam("code") Currency code
+	);
+}

--- a/src/main/java/SN/BANK/exchangeRate/manana/ExchangeRateMananaService.java
+++ b/src/main/java/SN/BANK/exchangeRate/manana/ExchangeRateMananaService.java
@@ -1,0 +1,24 @@
+package SN.BANK.exchangeRate.manana;
+
+import SN.BANK.account.enums.Currency;
+import SN.BANK.exchangeRate.manana.dto.ExchangeRateMananaResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExchangeRateMananaService {
+
+	private final ExchangeRateMananaClient exchangeRateMananaClient;
+
+	public BigDecimal getExchangeRate(Currency fromCurrency, Currency toCurrency) {
+		List<ExchangeRateMananaResponseDto> result = exchangeRateMananaClient.getExchangeRate(toCurrency, fromCurrency);
+		return result.get(0).rate().setScale(2, RoundingMode.CEILING);
+	}
+}

--- a/src/main/java/SN/BANK/exchangeRate/manana/ExchangeRateMananaService.java
+++ b/src/main/java/SN/BANK/exchangeRate/manana/ExchangeRateMananaService.java
@@ -1,6 +1,7 @@
 package SN.BANK.exchangeRate.manana;
 
 import SN.BANK.account.enums.Currency;
+import SN.BANK.exchangeRate.ExchangeRateOpenApiInterface;
 import SN.BANK.exchangeRate.manana.dto.ExchangeRateMananaResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,12 +14,13 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class ExchangeRateMananaService {
+public class ExchangeRateMananaService implements ExchangeRateOpenApiInterface {
 
 	private final ExchangeRateMananaClient exchangeRateMananaClient;
 
-	public BigDecimal getExchangeRate(Currency fromCurrency, Currency toCurrency) {
-		List<ExchangeRateMananaResponseDto> result = exchangeRateMananaClient.getExchangeRate(toCurrency, fromCurrency);
+	@Override
+	public BigDecimal getExchangeRate(Currency baseCurrency, Currency quoteCurrency) {
+		List<ExchangeRateMananaResponseDto> result = exchangeRateMananaClient.getExchangeRate(quoteCurrency, baseCurrency);
 		return result.get(0).rate().setScale(2, RoundingMode.CEILING);
 	}
 }

--- a/src/main/java/SN/BANK/exchangeRate/manana/dto/ExchangeRateMananaResponseDto.java
+++ b/src/main/java/SN/BANK/exchangeRate/manana/dto/ExchangeRateMananaResponseDto.java
@@ -1,0 +1,15 @@
+package SN.BANK.exchangeRate.manana.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExchangeRateMananaResponseDto (
+	@JsonProperty("data") String data,
+	@JsonProperty("name") String name,
+	@JsonProperty("rate") BigDecimal rate,
+	@JsonProperty("timestamp") long timestamp
+) {
+}

--- a/src/main/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverClient.java
+++ b/src/main/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverClient.java
@@ -1,0 +1,29 @@
+package SN.BANK.exchangeRate.naver;
+
+import SN.BANK.account.enums.Currency;
+import SN.BANK.exchangeRate.naver.dto.ExchangeRateNaverResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+	name = "naver-exchange-rate-service",
+	url = "${exchange-rate.naver.host}"
+)
+public interface ExchangeRateNaverClient {
+
+	@GetMapping("${exchange-rate.naver.url}}")
+	ExchangeRateNaverResponseDto getExchangeRate(
+		@RequestParam("key") String key,
+		@RequestParam("pkid") String pkid,
+		@RequestParam("q") String q,
+		@RequestParam("where") String where,
+		@RequestParam("u1") String u1,
+		@RequestParam("u6") String u6,
+		@RequestParam("u7") String u7,
+		@RequestParam("u3") Currency fromCurrency,
+		@RequestParam("u4") Currency toCurrency,
+		@RequestParam("u8") String u8,
+		@RequestParam("u2") String u2
+	);
+}

--- a/src/main/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverService.java
+++ b/src/main/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 @Service
 @RequiredArgsConstructor
@@ -69,6 +70,6 @@ public class ExchangeRateNaverService implements ExchangeRateOpenApiInterface {
 
 	private BigDecimal convertToBigDecimal(String value) {
 		value = value.replace(",", "");
-		return new BigDecimal(value);
+		return new BigDecimal(value).setScale(2, RoundingMode.CEILING);
 	}
 }

--- a/src/main/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverService.java
+++ b/src/main/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverService.java
@@ -1,6 +1,7 @@
 package SN.BANK.exchangeRate.naver;
 
 import SN.BANK.account.enums.Currency;
+import SN.BANK.exchangeRate.ExchangeRateOpenApiInterface;
 import SN.BANK.exchangeRate.naver.dto.ExchangeRateNaverResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,7 +11,7 @@ import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor
-public class ExchangeRateNaverService {
+public class ExchangeRateNaverService implements ExchangeRateOpenApiInterface {
 
 	private final ExchangeRateNaverClient exchangeRateNaverClient;
 
@@ -41,7 +42,8 @@ public class ExchangeRateNaverService {
 	@Value("${exchange-rate.naver.request-param.u2}")
 	private String u2;
 
-	public BigDecimal getExchangeRate(Currency fromCurrency, Currency toCurrency) {
+	@Override
+	public BigDecimal getExchangeRate(Currency baseCurrency, Currency quoteCurrency) {
 		ExchangeRateNaverResponseDto result = exchangeRateNaverClient.getExchangeRate(
 			key,
 			pkid,
@@ -50,8 +52,8 @@ public class ExchangeRateNaverService {
 			u1,
 			u6,
 			u7,
-			fromCurrency,
-			toCurrency,
+			baseCurrency,
+			quoteCurrency,
 			u8,
 			u2
 		);

--- a/src/main/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverService.java
+++ b/src/main/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverService.java
@@ -1,6 +1,8 @@
 package SN.BANK.exchangeRate.naver;
 
 import SN.BANK.account.enums.Currency;
+import SN.BANK.common.exception.CustomException;
+import SN.BANK.common.exception.ErrorCode;
 import SN.BANK.exchangeRate.ExchangeRateOpenApiInterface;
 import SN.BANK.exchangeRate.naver.dto.ExchangeRateNaverResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +46,10 @@ public class ExchangeRateNaverService implements ExchangeRateOpenApiInterface {
 
 	@Override
 	public BigDecimal getExchangeRate(Currency baseCurrency, Currency quoteCurrency) {
+		if(!quoteCurrency.equals(Currency.KRW)) {
+			throw new CustomException(ErrorCode.INVALID_QUOTE_CURRENCY_ERROR);
+		}
+
 		ExchangeRateNaverResponseDto result = exchangeRateNaverClient.getExchangeRate(
 			key,
 			pkid,

--- a/src/main/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverService.java
+++ b/src/main/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverService.java
@@ -1,0 +1,66 @@
+package SN.BANK.exchangeRate.naver;
+
+import SN.BANK.account.enums.Currency;
+import SN.BANK.exchangeRate.naver.dto.ExchangeRateNaverResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class ExchangeRateNaverService {
+
+	private final ExchangeRateNaverClient exchangeRateNaverClient;
+
+	@Value("${exchange-rate.naver.request-param.key}")
+	private String key;
+
+	@Value("${exchange-rate.naver.request-param.pkid}")
+	private String pkid;
+
+	@Value("${exchange-rate.naver.request-param.q}")
+	private String query;
+
+	@Value("${exchange-rate.naver.request-param.where}")
+	private String where;
+
+	@Value("${exchange-rate.naver.request-param.u1}")
+	private String u1;
+
+	@Value("${exchange-rate.naver.request-param.u6}")
+	private String u6;
+
+	@Value("${exchange-rate.naver.request-param.u7}")
+	private String u7;
+
+	@Value("${exchange-rate.naver.request-param.u8}")
+	private String u8;
+
+	@Value("${exchange-rate.naver.request-param.u2}")
+	private String u2;
+
+	public BigDecimal getExchangeRate(Currency fromCurrency, Currency toCurrency) {
+		ExchangeRateNaverResponseDto result = exchangeRateNaverClient.getExchangeRate(
+			key,
+			pkid,
+			query,
+			where,
+			u1,
+			u6,
+			u7,
+			fromCurrency,
+			toCurrency,
+			u8,
+			u2
+		);
+
+		return convertToBigDecimal(result.country().get(1).value());
+	}
+
+	private BigDecimal convertToBigDecimal(String value) {
+		value = value.replace(",", "");
+		return new BigDecimal(value);
+	}
+}

--- a/src/main/java/SN/BANK/exchangeRate/naver/dto/ExchangeRateNaverResponseDto.java
+++ b/src/main/java/SN/BANK/exchangeRate/naver/dto/ExchangeRateNaverResponseDto.java
@@ -1,0 +1,20 @@
+package SN.BANK.exchangeRate.naver.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExchangeRateNaverResponseDto (
+	@JsonProperty("pkid") int pkid,
+	@JsonProperty("count") int count,
+	@JsonProperty("country") List<Country> country,
+	@JsonProperty("calculatorMessage") String calculatorMessage
+) {
+	public record Country (
+		@JsonProperty("value") String value,
+		@JsonProperty("subValue") String subValue,
+		@JsonProperty("currencyUnit") String currencyUnit
+	) {}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,20 @@ server:
   servlet:
     session:
       timeout: 30m
+
+exchange-rate:
+  naver:
+    host: https://m.search.naver.com
+    url: /p/csearch/content/qapirender.nhn
+    request-param:
+      key: calculator
+      pkid: 141
+      q: "%ED%99%98%EC%9C%A8"
+      where: m
+      u1: keb
+      u6: standardUnit
+      u7: 0
+      u3: USD
+      u4: KRW
+      u8: down
+      u2: 1

--- a/src/test/java/SN/BANK/exchangeRate/ExchangeRateServiceMockTest.java
+++ b/src/test/java/SN/BANK/exchangeRate/ExchangeRateServiceMockTest.java
@@ -1,0 +1,86 @@
+package SN.BANK.exchangeRate;
+
+import SN.BANK.account.enums.Currency;
+import SN.BANK.exchangeRate.naver.ExchangeRateNaverService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ExchangeRateServiceMockTest {
+
+	@InjectMocks
+	ExchangeRateService exchangeRateService;
+
+	@Mock
+	ExchangeRateNaverService exchangeRateNaverService;
+
+	@DisplayName("같은 currency 업데이트 작업은 1개의 스레드만 가능하며, currency가 다른 경우 동시에 환율 업데이트 로직을 수행해도 된다.")
+	@Test
+	void currency_only_reentrant_lock_test() throws InterruptedException {
+		Mockito.when(exchangeRateNaverService.getExchangeRate(any(), any()))
+			.thenReturn(new BigDecimal(1));
+
+		// 멀티스레드 환경 설정
+		int threadCount = 20;
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		List<Future<Void>> futures = new ArrayList<>();
+
+		// USD/KRW 작업 생성
+		for(int i = 0; i < threadCount; i++) {
+			futures.add(executorService.submit(() -> {
+				try {
+				exchangeRateService.getExchangeRate(Currency.KRW, Currency.USD);
+				} finally {
+					latch.countDown();
+				}
+				return null;
+			}));
+		}
+
+		// EUR/KRW 작업 생성
+		for(int i = 0; i < threadCount; i++) {
+			futures.add(executorService.submit(() -> {
+				try {
+					exchangeRateService.getExchangeRate(Currency.KRW, Currency.EUR);
+				} finally {
+					latch.countDown();
+				}
+				return null;
+			}));
+		}
+
+		// 모든 작업 실행
+		for (Future<Void> future : futures) {
+			try {
+				future.get(); // 각 future 실행 및 예외 대기
+			} catch (ExecutionException e) {
+				fail("Task execution failed: " + e.getMessage());
+			}
+		}
+		latch.await(5, TimeUnit.SECONDS);
+		executorService.shutdown();
+
+		// USD/KRW 환율 업데이트 1회 작업 확인
+		verify(exchangeRateNaverService, times(1))
+			.getExchangeRate(Currency.USD, Currency.KRW);
+
+		// EUR/KRW 환율 업데이트 1회 작업 확인
+		verify(exchangeRateNaverService, times(1))
+			.getExchangeRate(Currency.EUR, Currency.KRW);
+	}
+}

--- a/src/test/java/SN/BANK/exchangeRate/ExchangeRateServiceTest.java
+++ b/src/test/java/SN/BANK/exchangeRate/ExchangeRateServiceTest.java
@@ -1,0 +1,57 @@
+package SN.BANK.exchangeRate;
+
+import SN.BANK.account.enums.Currency;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ExchangeRateServiceTest {
+
+	@Autowired
+	ExchangeRateService exchangeRateService;
+
+	@DisplayName("송금인 계좌 단위가 USD인 경우 환율 데이터가 1 미만이 반환되어야 한다.")
+	@Test
+	void sender_USD_currency_test() {
+		BigDecimal exchangeRate = exchangeRateService.getExchangeRate(Currency.USD, Currency.KRW);
+
+		assertNotNull(exchangeRate);
+		assertThat(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertThat(exchangeRate.compareTo(BigDecimal.ONE) < 1);
+
+		System.out.println("KRW/USD 환율 결과: " + exchangeRate);
+	}
+
+	@DisplayName("송금인 계좌 단위가 EUR인 경우 환율 데이터가 1 미만이 반환되어야 한다.")
+	@Test
+	void sender_EUR_currency_test() {
+		BigDecimal exchangeRate = exchangeRateService.getExchangeRate(Currency.EUR, Currency.KRW);
+
+		assertNotNull(exchangeRate);
+		assertThat(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertThat(exchangeRate.compareTo(BigDecimal.ONE) < 1);
+
+		System.out.println("KRW/USD 환율 결과: " + exchangeRate);
+	}
+
+	@DisplayName("송금인 계좌 단위가 KRW 인 경우 환율 데이터가 1 이상이 반환되어야 한다.")
+	@Test
+	void KRW_USE_test() {
+		BigDecimal exchangeRate = exchangeRateService.getExchangeRate(Currency.KRW, Currency.USD);
+
+		assertNotNull(exchangeRate);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertEquals(2, exchangeRate.scale());
+
+		System.out.println("USD/KRW 환율 결과: " + exchangeRate);
+	}
+}

--- a/src/test/java/SN/BANK/exchangeRate/google/ExchangeRateGoogleFinanceScraperTest.java
+++ b/src/test/java/SN/BANK/exchangeRate/google/ExchangeRateGoogleFinanceScraperTest.java
@@ -1,6 +1,7 @@
 package SN.BANK.exchangeRate.google;
 
 import SN.BANK.account.enums.Currency;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,25 +18,27 @@ class ExchangeRateGoogleFinanceScraperTest {
 	@Autowired
 	ExchangeRateGoogleFinanceScraper exchangeRateGoogleFinanceScraper;
 
+	@DisplayName("Google 서비스로 USD/KRW 요청 시 1 이상의 값을 반환해야 한다.")
 	@Test
 	void USD_KRW_test() {
 		BigDecimal exchangeRate = exchangeRateGoogleFinanceScraper.getExchangeRate(Currency.USD, Currency.KRW);
 
 		assertNotNull(exchangeRate);
-		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ONE) > 0);
 		assertEquals(2, exchangeRate.scale());
 
-		System.out.println("[Google] " +  Currency.USD + " " + exchangeRate);
+		System.out.println("[Google] USD/KRW " + exchangeRate);
 	}
 
+	@DisplayName("Google 서비스로 EUR/KRW 요청 시 1 이상의 값을 반환해야 한다.")
 	@Test
 	void EUR_KRW_test() {
 		BigDecimal exchangeRate = exchangeRateGoogleFinanceScraper.getExchangeRate(Currency.EUR, Currency.KRW);
 
 		assertNotNull(exchangeRate);
-		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ONE) > 0);
 		assertEquals(2, exchangeRate.scale());
 
-		System.out.println("[Google] " +  Currency.EUR + " " + exchangeRate);
+		System.out.println("[Google] EUR/KRW " + exchangeRate);
 	}
 }

--- a/src/test/java/SN/BANK/exchangeRate/google/ExchangeRateGoogleFinanceScraperTest.java
+++ b/src/test/java/SN/BANK/exchangeRate/google/ExchangeRateGoogleFinanceScraperTest.java
@@ -1,0 +1,41 @@
+package SN.BANK.exchangeRate.google;
+
+import SN.BANK.account.enums.Currency;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ExchangeRateGoogleFinanceScraperTest {
+
+	@Autowired
+	ExchangeRateGoogleFinanceScraper exchangeRateGoogleFinanceScraper;
+
+	@Test
+	void USD_KRW_test() {
+		BigDecimal exchangeRate = exchangeRateGoogleFinanceScraper.getExchangeRate(Currency.USD, Currency.KRW);
+
+		assertNotNull(exchangeRate);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertEquals(2, exchangeRate.scale());
+
+		System.out.println("[Google] " +  Currency.USD + " " + exchangeRate);
+	}
+
+	@Test
+	void EUR_KRW_test() {
+		BigDecimal exchangeRate = exchangeRateGoogleFinanceScraper.getExchangeRate(Currency.EUR, Currency.KRW);
+
+		assertNotNull(exchangeRate);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertEquals(2, exchangeRate.scale());
+
+		System.out.println("[Google] " +  Currency.EUR + " " + exchangeRate);
+	}
+}

--- a/src/test/java/SN/BANK/exchangeRate/manana/ExchangeRateMananaServiceTest.java
+++ b/src/test/java/SN/BANK/exchangeRate/manana/ExchangeRateMananaServiceTest.java
@@ -1,0 +1,41 @@
+package SN.BANK.exchangeRate.manana;
+
+import SN.BANK.account.enums.Currency;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ExchangeRateMananaServiceTest {
+
+	@Autowired
+	ExchangeRateMananaService exchangeRateMananaService;
+
+	@Test
+	void USD_KRW_test() {
+		BigDecimal exchangeRate = exchangeRateMananaService.getExchangeRate(Currency.USD, Currency.KRW);
+
+		assertNotNull(exchangeRate);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertEquals(2, exchangeRate.scale());
+
+		System.out.println("[Manana] " +  Currency.USD + " " + exchangeRate);
+	}
+
+	@Test
+	void EUR_KRW_test() {
+		BigDecimal exchangeRate = exchangeRateMananaService.getExchangeRate(Currency.EUR, Currency.KRW);
+
+		assertNotNull(exchangeRate);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertEquals(2, exchangeRate.scale());
+
+		System.out.println("[Manana] " +  Currency.EUR + " " + exchangeRate);
+	}
+}

--- a/src/test/java/SN/BANK/exchangeRate/manana/ExchangeRateMananaServiceTest.java
+++ b/src/test/java/SN/BANK/exchangeRate/manana/ExchangeRateMananaServiceTest.java
@@ -1,6 +1,7 @@
 package SN.BANK.exchangeRate.manana;
 
 import SN.BANK.account.enums.Currency;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,25 +18,27 @@ class ExchangeRateMananaServiceTest {
 	@Autowired
 	ExchangeRateMananaService exchangeRateMananaService;
 
+	@DisplayName("Manana 서비스로 USD/KRW 요청 시 1 이상의 값을 반환해야 한다.")
 	@Test
 	void USD_KRW_test() {
 		BigDecimal exchangeRate = exchangeRateMananaService.getExchangeRate(Currency.USD, Currency.KRW);
 
 		assertNotNull(exchangeRate);
-		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ONE) > 0);
 		assertEquals(2, exchangeRate.scale());
 
-		System.out.println("[Manana] " +  Currency.USD + " " + exchangeRate);
+		System.out.println("[Manana] USD/KRW " + exchangeRate);
 	}
 
+	@DisplayName("Manana 서비스로 EUR/KRW 요청 시 1 이상의 값을 반환해야 한다.")
 	@Test
 	void EUR_KRW_test() {
 		BigDecimal exchangeRate = exchangeRateMananaService.getExchangeRate(Currency.EUR, Currency.KRW);
 
 		assertNotNull(exchangeRate);
-		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ONE) > 0);
 		assertEquals(2, exchangeRate.scale());
 
-		System.out.println("[Manana] " +  Currency.EUR + " " + exchangeRate);
+		System.out.println("[Manana] EUR/KRW " + exchangeRate);
 	}
 }

--- a/src/test/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverServiceTest.java
+++ b/src/test/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverServiceTest.java
@@ -4,6 +4,7 @@ import SN.BANK.account.enums.Currency;
 import SN.BANK.common.exception.CustomException;
 import SN.BANK.common.exception.ErrorCode;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,28 +22,31 @@ class ExchangeRateNaverServiceTest {
 	@Autowired
 	ExchangeRateNaverService exchangeRateNaverService;
 
+	@DisplayName("Naver 서비스로 USD/KRW 요청 시 1 이상의 값을 반환해야 한다.")
 	@Test
 	void USD_KRW_test() {
 		BigDecimal exchangeRate = exchangeRateNaverService.getExchangeRate(Currency.USD, Currency.KRW);
 
 		assertNotNull(exchangeRate);
-		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ONE) > 0);
 		assertEquals(2, exchangeRate.scale());
 
 		System.out.println("[Naver] USD/KRW " + exchangeRate);
 	}
 
+	@DisplayName("Naver 서비스로 EUR/KRW 요청 시 1 이상의 값을 반환해야 한다.")
 	@Test
 	void EUR_KRW_test() {
 		BigDecimal exchangeRate = exchangeRateNaverService.getExchangeRate(Currency.EUR, Currency.KRW);
 
 		assertNotNull(exchangeRate);
-		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ONE) > 0);
 		assertEquals(2, exchangeRate.scale());
 
 		System.out.println("[Naver] EUR/KRW " + exchangeRate);
 	}
 
+	@DisplayName("Naver 서비스로 환율 요청 시 Quote Currency가 KRW 단위가 아니면 예외를 날린다")
 	@Test
 	void quote_currency_status_check_test() {
 		Assertions.assertThatThrownBy(() -> exchangeRateNaverService.getExchangeRate(Currency.KRW, Currency.USD))

--- a/src/test/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverServiceTest.java
+++ b/src/test/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverServiceTest.java
@@ -1,9 +1,13 @@
 package SN.BANK.exchangeRate.naver;
 
 import SN.BANK.account.enums.Currency;
+import SN.BANK.common.exception.CustomException;
+import SN.BANK.common.exception.ErrorCode;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
@@ -25,7 +29,7 @@ class ExchangeRateNaverServiceTest {
 		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
 		assertEquals(2, exchangeRate.scale());
 
-		System.out.println("[Naver] " +  Currency.USD + " " + exchangeRate);
+		System.out.println("[Naver] USD/KRW " + exchangeRate);
 	}
 
 	@Test
@@ -36,6 +40,18 @@ class ExchangeRateNaverServiceTest {
 		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
 		assertEquals(2, exchangeRate.scale());
 
-		System.out.println("[Naver] " +  Currency.EUR + " " + exchangeRate);
+		System.out.println("[Naver] EUR/KRW " + exchangeRate);
+	}
+
+	@Test
+	void quote_currency_status_check_test() {
+		Assertions.assertThatThrownBy(() -> exchangeRateNaverService.getExchangeRate(Currency.KRW, Currency.USD))
+			.isInstanceOf(CustomException.class)
+			.satisfies(ex -> {
+				CustomException customException = (CustomException) ex;
+				assertEquals(ErrorCode.INVALID_QUOTE_CURRENCY_ERROR, customException.getErrorCode());
+				assertEquals(HttpStatus.BAD_REQUEST, customException.getErrorCode().getStatus());
+				assertEquals("Quote Currency는 한국 원화(KRW) 단위여야 합니다.", customException.getErrorCode().getMessage());
+			});
 	}
 }

--- a/src/test/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverServiceTest.java
+++ b/src/test/java/SN/BANK/exchangeRate/naver/ExchangeRateNaverServiceTest.java
@@ -1,0 +1,41 @@
+package SN.BANK.exchangeRate.naver;
+
+import SN.BANK.account.enums.Currency;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ExchangeRateNaverServiceTest {
+
+	@Autowired
+	ExchangeRateNaverService exchangeRateNaverService;
+
+	@Test
+	void USD_KRW_test() {
+		BigDecimal exchangeRate = exchangeRateNaverService.getExchangeRate(Currency.USD, Currency.KRW);
+
+		assertNotNull(exchangeRate);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertEquals(2, exchangeRate.scale());
+
+		System.out.println("[Naver] " +  Currency.USD + " " + exchangeRate);
+	}
+
+	@Test
+	void EUR_KRW_test() {
+		BigDecimal exchangeRate = exchangeRateNaverService.getExchangeRate(Currency.EUR, Currency.KRW);
+
+		assertNotNull(exchangeRate);
+		assertTrue(exchangeRate.compareTo(BigDecimal.ZERO) > 0);
+		assertEquals(2, exchangeRate.scale());
+
+		System.out.println("[Naver] " +  Currency.EUR + " " + exchangeRate);
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
refactor/exchange-rate-open-api -> dev

### 이슈
- close #27 

### 작업 사항
- 구글 환율 웹 스크래핑
- naver, manana open api 연결
- 1차 실행: naver
- 2차 실행: 구글 웹 스크래핑, manana 서비스 동시 실행
- 1차 실행 -> 2차 실행 시 동기 방식으로 2차 실행 로직 강제함 (exceptionallyAsync 사용 시 2차 실행 로직이 언제 실행되는지 파악 불가)
- 2차 실행 부분에서 구글 웹 스크래핑, manana 두 서비스를 동시 실행해 가장 빨리 응답 오는 값으로 업데이트
- 외부로 환율 데이터 요청하는 로직에 스레드 제한하여 네트워크 비용 절감

### 전달 사항
- redis 캐싱 부분 진행하지 못함
- KRW/외화의 경우 0.00069381808089918823 로 반환되는데 소수점 사용에 대한 합의 필요
- naver 서비스만 KRW/외화 결과를 제대로 받아오지 못함 (현재 역수 계산으로 대체)
- **build.gradle 변경됨**
