### PR TITLE
feat: 결제, 결제 취소기능 동시성제어 적용

### DIFF
--- a/src/main/java/SN/BANK/account/repository/AccountRepository.java
+++ b/src/main/java/SN/BANK/account/repository/AccountRepository.java
@@ -2,7 +2,11 @@ package SN.BANK.account.repository;
 
 import SN.BANK.account.entity.Account;
 import SN.BANK.users.entity.Users;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +17,8 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     boolean existsByAccountNumber(String accountNumber);
     List<Account> findByUser(Users user);
     Optional<Account> findByAccountNumber(String accountNumber);
+
+    @Query("SELECT a FROM Account a WHERE a.accountNumber = :accountNumber")
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Account> findByAccountNumberWithLock(@Param("accountNumber") String accountNumber);
 }

--- a/src/main/java/SN/BANK/payment/entity/PaymentList.java
+++ b/src/main/java/SN/BANK/payment/entity/PaymentList.java
@@ -12,7 +12,8 @@ import java.time.LocalDateTime;
     @Entity
     @Getter
     @AllArgsConstructor
-
+    @NoArgsConstructor
+    
     public class PaymentList {
 
         @Id

--- a/src/main/java/SN/BANK/payment/repository/PaymentListRepository.java
+++ b/src/main/java/SN/BANK/payment/repository/PaymentListRepository.java
@@ -1,9 +1,19 @@
 package SN.BANK.payment.repository;
 
 import SN.BANK.payment.entity.PaymentList;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface PaymentListRepository extends JpaRepository<PaymentList,Long> {
+
+    @Query("SELECT p FROM PaymentList p WHERE p.id = :paymentId")
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<PaymentList> findByIdWithLock(@Param("paymentId") Long paymentId);
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/payment-concurrency-control -> dev

### 이슈
- 이슈 번호 없음

### 작업 사항
#### 동시성 제어 적용
- PESSIMISTIC_WRITE Lock 사용: 결제 및 취소 시 동시 데이터 접근 방지.
- 트랜잭션 관리: @Transactional과 Isolation.REPEATABLE_READ를 사용하여 데이터 정합성을 유지.
- 데드락 방지: 계좌 조회 시 항상 계좌번호순으로 Lock 순서가 일관되도록 처리하여 Lock 순서의 충돌로 인해 발생할 수 있는 데드락 상황을 예방.