### PR TITLE
fix: 잔액 업데이트 메서드 매개변수 수정

### DIFF
--- a/src/main/java/SN/BANK/transaction/service/TransactionService.java
+++ b/src/main/java/SN/BANK/transaction/service/TransactionService.java
@@ -65,7 +65,7 @@ public class TransactionService {
         updateAccountBalance(senderAccount, convertedAmount, receiverAccount, amount);
 
         return createTransactionRecords(senderAccount, receiverAccount,
-                exchangeRate, amount, convertedAmount);
+                exchangeRate, convertedAmount, amount);
     }
 
     /**
@@ -124,8 +124,8 @@ public class TransactionService {
     }
 
     private void updateAccountBalance(Account senderAccount, BigDecimal convertedAmount, Account receiverAccount, BigDecimal amount) {
-        senderAccount.decreaseMoney(amount);
-        receiverAccount.increaseMoney(convertedAmount);
+        senderAccount.decreaseMoney(convertedAmount);
+        receiverAccount.increaseMoney(amount);
     }
 
     private BigDecimal getExchangeAmount(BigDecimal exchangeRate, BigDecimal amount) {
@@ -214,16 +214,16 @@ public class TransactionService {
 
     // Transaction (거래 내역) 생성 메서드
     public TransactionResponse createTransactionRecords(Account senderAccount, Account receiverAccount,
-                                                        BigDecimal exchangeRate, BigDecimal amount, BigDecimal convertedAmount) {
+                                                        BigDecimal exchangeRate, BigDecimal convertedAmount, BigDecimal amount) {
 
         LocalDateTime transactedAt = LocalDateTime.now();
         String txGroupId = generateTransactionGroupId();
 
         TransactionEntity senderTx = buildTransactionEntity(senderAccount, receiverAccount, TransactionType.WITHDRAWAL, transactedAt,
-                amount, senderAccount.getCurrency(), exchangeRate, senderAccount.getMoney(), txGroupId);
+                convertedAmount, senderAccount.getCurrency(), exchangeRate, senderAccount.getMoney(), txGroupId);
 
         TransactionEntity receiverTx = buildTransactionEntity(senderAccount, receiverAccount, TransactionType.DEPOSIT, transactedAt,
-                convertedAmount, receiverAccount.getCurrency(), exchangeRate, receiverAccount.getMoney(), txGroupId);
+                amount, receiverAccount.getCurrency(), exchangeRate, receiverAccount.getMoney(), txGroupId);
 
         transactionRepository.saveAll(List.of(senderTx, receiverTx));
 
@@ -258,7 +258,7 @@ public class TransactionService {
         updateAccountBalance(senderAccount, convertedAmount, receiverAccount, amount);
 
         return createTransactionRecords(senderAccount, receiverAccount,
-                exchangeRate, amount, convertedAmount);
+                exchangeRate, convertedAmount, amount);
     }
 
     private TransactionAccountsResponse getTransferAccountsNonLock(TransactionRequest txRequest) {

--- a/src/main/java/SN/BANK/transaction/service/TransactionService.java
+++ b/src/main/java/SN/BANK/transaction/service/TransactionService.java
@@ -80,7 +80,7 @@ public class TransactionService {
         BigDecimal convertedAmount = getExchangeAmount(exchangeRate, amount);
 
         // 보낸 사람 돈 감소, 받는 사람 돈 증가
-        updateAccountBalance(senderAccount, amount, receiverAccount, convertedAmount);
+        updateAccountBalance(senderAccount, convertedAmount, receiverAccount, amount);
 
         // 거래내역 생성
         createTransactionRecords(senderAccount, receiverAccount,
@@ -123,7 +123,7 @@ public class TransactionService {
         accountService.validateNotSelfTransfer(sennderAccount, receiverAccount);
     }
 
-    private void updateAccountBalance(Account senderAccount, BigDecimal amount, Account receiverAccount, BigDecimal convertedAmount) {
+    private void updateAccountBalance(Account senderAccount, BigDecimal convertedAmount, Account receiverAccount, BigDecimal amount) {
         senderAccount.decreaseMoney(amount);
         receiverAccount.increaseMoney(convertedAmount);
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/transaction-balance-update-parameters -> dev

### 이슈
이슈 번호 없음

### 작업 사항
#### createTransactionForPayment -> updateAccountBalance 의 파라미터에서 amount와 convertedAmount 의 위치가 서로 바뀌었습니다.
- (senderAccount, amount, receiverAccount, convertedAmount) => (senderAccount, convertedAmount, receiverAccount, amount) 로 변경